### PR TITLE
Remover assinatura plano

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # SafeBox
+
+### Testes do Behave
+
+- Executar uma única feature
+  - behave features/feature_name.feature
+- Executar um único cenário
+  - behave -n "Escreva o cenario aqui"

--- a/projetao/features/assinatura.feature
+++ b/projetao/features/assinatura.feature
@@ -24,5 +24,14 @@ Feature: Assign a plan to my user account
         And I click on Mudar de plano
         And I can see my new signature
 
+    Scenario: As a cliente of the system, I want to remove the current signature
+        Given I am on the Profile View
+        And I have a signature
+        When I click on the Visualizar Assinatura button
+        Then I go to my signature view
+        And I click on Remover Plano
+        And I can see the message confirm
+        And I click on confirm button 'OK'
+        And I can see the Profile View
 
 

--- a/projetao/features/steps/assinatura.py
+++ b/projetao/features/steps/assinatura.py
@@ -105,7 +105,25 @@ def step_impl(context):
 def step_impl(context):
     assert context.browser.title=="Assinatura"
 
+@Then('I click on Remover Plano')
+def step_impl(context):
+    button = context.browser.find_element_by_name("remover_plano")
+    button.click()
 
+@Then('I can see the message confirm')
+def step_impl(context):
+    confirm = context.browser.switch_to.alert
+    texto = confirm.text
+    assert texto == "Essa assinatura será removida! Deseja continuar?"
 
+@Then('I click on confirm button \'OK\'')
+def step_impl(context):
+    confirm = context.browser.switch_to.alert
+    confirm.accept()
+
+@Then('I can see the Profile View')
+def step_impl(context):
+    title = context.browser.title
+    assert title == "Meu Perfil"
 
 

--- a/projetao/safebox/templates/cliente_assinatura_view.html
+++ b/projetao/safebox/templates/cliente_assinatura_view.html
@@ -80,6 +80,7 @@
                     {% csrf_token %}
                     <input type="submit" class="btn btn-primary" value="Voltar" name="voltar"/>
                     <input type="submit" class="btn btn-primary" value="Trocar Plano" name="trocar_plano"/>
+                    <input type="submit" onclick="return confirm('Essa assinatura será removida! Deseja continuar?')" class="btn btn-danger fix-size" value="Remover Plano" name="remover_plano"/>
                 </form>
             </div>
         </div>

--- a/projetao/safebox/views.py
+++ b/projetao/safebox/views.py
@@ -75,8 +75,9 @@ def cliente_assinatura_view(request, email):
         return redirect('trocar_assinatura', email)
 
     if action_remover == 'Remover Plano':
-        messages.success(request, "Esta assinatura foi removida!")
+        #messages.info(request, "Assinatura desfeita com sucesso!")
         remover_assinatura(request, email)
+        return redirect('visualizar', email)
 
     return render(request, "cliente_assinatura_view.html", context)
 
@@ -86,12 +87,11 @@ def remover_assinatura(request, email):
     assinatura = assinaturas.filter(cliente_id=cliente.id)
 
     flag_assinatura_existente = False
-    if (assinatura != None) and (len(assinatura) != 0):
+    if (assinatura != None and len(assinatura)):
         flag_assinatura_existente = True
 
     if flag_assinatura_existente:
-        assinatura.delete()
-        return redirect('visualizar', email)
+        assinatura[0].delete()
 
 def cliente_edit_view(request, email):
     context = {}

--- a/projetao/safebox/views.py
+++ b/projetao/safebox/views.py
@@ -66,6 +66,7 @@ def cliente_assinatura_view(request, email):
 
     action_voltar = request.POST.get('voltar')
     action_trocar = request.POST.get('trocar_plano')
+    action_remover = request.POST.get('remover_plano')
 
     if action_voltar == 'Voltar':
         return redirect('visualizar',email)
@@ -73,8 +74,24 @@ def cliente_assinatura_view(request, email):
     if action_trocar == 'Trocar Plano':
         return redirect('trocar_assinatura', email)
 
+    if action_remover == 'Remover Plano':
+        messages.success(request, "Esta assinatura foi removida!")
+        remover_assinatura(request, email)
+
     return render(request, "cliente_assinatura_view.html", context)
 
+def remover_assinatura(request, email):
+    cliente = Cliente.objects.get(email=email)
+    assinaturas = Assinatura.objects.all()
+    assinatura = assinaturas.filter(cliente_id=cliente.id)
+
+    flag_assinatura_existente = False
+    if (assinatura != None) and (len(assinatura) != 0):
+        flag_assinatura_existente = True
+
+    if flag_assinatura_existente:
+        assinatura.delete()
+        return redirect('visualizar', email)
 
 def cliente_edit_view(request, email):
     context = {}


### PR DESCRIPTION
Remoção de assinatura. O único model alterado é o da assinatura com o delete da instância alvo. É verificado se existem outras assinaturas do cliente, mas é deletada somente a primeira da query de 'Assinatura'.